### PR TITLE
Add CoVE aggregates to stats.json and to report.csv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install: pip install -r requirements.txt
 script:
   - mkdir -p data/{original,json_all,json_valid,json_acceptable_license,json_acceptable_license_valid}
+  # Don't convert big file becasue Travis doesn't have the RAM
   - python get.py --no-convert-big-files
   - python stats.py
   - python report.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ python:
   - "3.5"
 install: pip install -r requirements.txt
 script:
-  - mkdir -p data/{original,json_all,json_valid,json_acceptable_license,json_acceptable_license_valid}
   # Don't convert big file becasue Travis doesn't have the RAM
-  - travis_wait 30 python get.py --no-convert-big-files
-  - python stats.py
-  - python report.py
+  - travis_wait 60 ./run.sh --no-convert-big-files
 before_deploy:
   - mkdir -p deploy/branch/$TRAVIS_BRANCH
   - cp data/data_all.json data/report.csv data/stats.json deploy/branch/$TRAVIS_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ install: pip install -r requirements.txt
 script:
   - mkdir -p data/{original,json_all,json_valid,json_acceptable_license,json_acceptable_license_valid}
   - python get.py --no-convert-big-files
-  - python report.py
   - python stats.py
+  - python report.py
 before_deploy:
   - mkdir -p deploy/branch/$TRAVIS_BRANCH
   - cp data/data_all.json data/report.csv data/stats.json deploy/branch/$TRAVIS_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ deploy:
   skip_cleanup: true
   acl: public-read
   local-dir: deploy
+  cache_control: private
   on:
     all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+language: python
+python:
+  - "3.5"
+install: pip install -r requirements.txt
+script:
+  - mkdir -p data/{original,json_all,json_valid,json_acceptable_license,json_acceptable_license_valid}
+  - python get.py --no-convert-big-files
+  - python report.py
+  - python stats.py
+before_deploy:
+  - mkdir -p deploy/branch/$TRAVIS_BRANCH
+  - cp data/data_all.json data/report.csv data/stats.json deploy/branch/$TRAVIS_BRANCH
+deploy:
+  provider: gcs
+  access_key_id: "$ACCESS_KEY"
+  secret_access_key: "$SECRET"
+  bucket: "datagetter-360giving-output"
+  skip_cleanup: true
+  acl: public-read
+  local-dir: deploy
+  on:
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: pip install -r requirements.txt
 script:
   - mkdir -p data/{original,json_all,json_valid,json_acceptable_license,json_acceptable_license_valid}
   # Don't convert big file becasue Travis doesn't have the RAM
-  - python get.py --no-convert-big-files
+  - travis_wait 30 python get.py --no-convert-big-files
   - python stats.py
   - python report.py
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - travis_wait 60 ./run.sh --no-convert-big-files
 before_deploy:
   - mkdir -p deploy/branch/$TRAVIS_BRANCH
-  - cp data/data_all.json data/report.csv data/stats.json deploy/branch/$TRAVIS_BRANCH
+  - cp data/data_all.json data/report.csv data/status.json deploy/branch/$TRAVIS_BRANCH
 deploy:
   provider: gcs
   access_key_id: "$ACCESS_KEY"

--- a/aggregates.py
+++ b/aggregates.py
@@ -15,7 +15,7 @@ for dataset in data_all:
                 aggregates[k+'_count'] = len(v)
                 del aggregates[k]
         aggregates = {k:sorted(list(v)) if isinstance(v, set) else v for k,v in aggregates.items()}
-        dataset['datagetter_stats'] = aggregates
+        dataset['datagetter_aggregates'] = aggregates
     stats.append(dataset)
-    with open('data/stats.json', 'w') as fp:
+    with open('data/status.json', 'w') as fp:
         json.dump(stats, fp, indent='  ', sort_keys=True)

--- a/get.py
+++ b/get.py
@@ -12,8 +12,6 @@ import argparse
 import rfc6266  # (content-disposition header parser)
 from jsonschema import validate, ValidationError, FormatChecker
 
-exit_status = 0
-
 parser = argparse.ArgumentParser()
 parser.add_argument('--no-download', dest='download', action='store_false')
 parser.add_argument('--no-convert', dest='convert', action='store_false')
@@ -111,7 +109,6 @@ for dataset in data_all:
         except:
             print("\n\nDownload failed for dataset {}\n".format(dataset['identifier']))
             traceback.print_exc()
-            exit_status = 1
             metadata['downloads'] = False
         else:
             metadata['downloads'] = True
@@ -156,8 +153,6 @@ for dataset in data_all:
                 metadata['json'] = json_file_name
 
     metadata['acceptable_license'] = dataset['license'] in acceptable_licenses
-    if not metadata['acceptable_license']:
-        exit_status = 1
 
     # We can only do anything with the JSON if it did successfully convert.
     if metadata.get('json'):
@@ -193,5 +188,3 @@ for dataset in data_all:
         json.dump(data_acceptable_license, fp, indent=4)
     with open('data/data_acceptable_license_valid.json', 'w') as fp:
         json.dump(data_acceptable_license_valid, fp, indent=4)
-
-sys.exit(exit_status)

--- a/report.py
+++ b/report.py
@@ -1,15 +1,22 @@
 import csv
 import json
 
-with open('data/data_all.json') as fp:
+with open('data/stats.json') as fp:
     data_json = json.load(fp)
 
 with open('data/report.csv', 'w') as fp:
-    writer = csv.DictWriter(fp, ['publisher_name', 'title', 'downloadURL', 'datetime_downloaded', 'file_type', 'downloads', 'converts', 'valid', 'acceptable_license'])
+    writer = csv.DictWriter(fp, [
+        'publisher_name', 'title', 'downloadURL', 'datetime_downloaded',
+        'file_type', 'downloads', 'converts', 'valid', 'acceptable_license',
+        'count', 'unique_ids_count', 'distinct_funding_org_identifier_count',
+        'distinct_recipient_org_identifier_count', 'min_award_date',
+        'max_award_date',
+    ])
     writer.writeheader()
     for dataset in data_json:
         if 'datagetter_metadata' not in dataset:
             continue
+        stats = dataset.get('datagetter_stats', {})
         writer.writerow({
             'publisher_name': dataset['publisher']['name'],
             'title': dataset['title'],
@@ -20,4 +27,10 @@ with open('data/report.csv', 'w') as fp:
             'converts': bool(dataset['datagetter_metadata']['json']) if 'json' in dataset['datagetter_metadata'] else '',
             'valid': dataset['datagetter_metadata'].get('valid', ''),
             'acceptable_license': dataset['datagetter_metadata'].get('acceptable_license'),
+            'count': stats.get('count'),
+            'unique_ids_count': stats.get('unique_ids_count'),
+            'distinct_funding_org_identifier_count': stats.get('distinct_funding_org_identifier_count'),
+            'distinct_recipient_org_identifier_count': stats.get('distinct_recipient_org_identifier_count'),
+            'min_award_date': stats.get('min_award_date'),
+            'max_award_date': stats.get('min_award_date'),
         })

--- a/report.py
+++ b/report.py
@@ -1,5 +1,6 @@
 import csv
 import json
+from collections import defaultdict
 
 with open('data/stats.json') as fp:
     data_json = json.load(fp)
@@ -11,13 +12,26 @@ with open('data/report.csv', 'w') as fp:
         'converts', 'valid', 'acceptable_license', 'count', 'unique_ids_count',
         'distinct_funding_org_identifier_count',
         'distinct_recipient_org_identifier_count', 'min_award_date',
-        'max_award_date',
+        'max_award_date', 'total_amount_GBP', 'min_amount_GBP',
+        'max_amount_GBP', 'count_GBP', 'total_amount_not_GBP',
+        'min_amount_not_GBP', 'max_amount_not_GBP', 'count_not_GBP',
+        'currencies_not_GBP',
     ])
     writer.writeheader()
     for dataset in data_json:
         if 'datagetter_metadata' not in dataset:
             continue
         stats = dataset.get('datagetter_stats', {})
+
+        currencies = stats.get('currencies', {})
+        not_GBP = defaultdict(list)
+        for currency, currency_dict in currencies.items():
+            if currency == 'GBP':
+                continue
+            for field in 'min_amount', 'max_amount', 'total_amount', 'count':
+                not_GBP[field] += [str(currency_dict.get(field, ''))]
+            not_GBP['currencies'] += [currency]
+
         writer.writerow({
             'publisher_prefix': dataset['publisher']['prefix'],
             'publisher_name': dataset['publisher']['name'],
@@ -36,4 +50,13 @@ with open('data/report.csv', 'w') as fp:
             'distinct_recipient_org_identifier_count': stats.get('distinct_recipient_org_identifier_count'),
             'min_award_date': stats.get('min_award_date'),
             'max_award_date': stats.get('max_award_date'),
+            'total_amount_GBP': currencies.get('GBP', {}).get('total_amount'),
+            'min_amount_GBP': currencies.get('GBP', {}).get('min_amount'),
+            'max_amount_GBP': currencies.get('GBP', {}).get('max_amount'),
+            'count_GBP': currencies.get('GBP', {}).get('count'),
+            'total_amount_not_GBP': '; '.join(not_GBP['total_amount']),
+            'min_amount_not_GBP': '; '.join(not_GBP['min_amount']),
+            'max_amount_not_GBP': '; '.join(not_GBP['max_amount']),
+            'count_not_GBP': '; '.join(not_GBP['count']),
+            'currencies_not_GBP': '; '.join(not_GBP['currencies']),
         })

--- a/report.py
+++ b/report.py
@@ -6,9 +6,10 @@ with open('data/stats.json') as fp:
 
 with open('data/report.csv', 'w') as fp:
     writer = csv.DictWriter(fp, [
-        'publisher_name', 'title', 'downloadURL', 'datetime_downloaded',
-        'file_type', 'downloads', 'converts', 'valid', 'acceptable_license',
-        'count', 'unique_ids_count', 'distinct_funding_org_identifier_count',
+        'publisher_prefix', 'publisher_name', 'title', 'accessURL',
+        'downloadURL', 'datetime_downloaded', 'file_type', 'downloads',
+        'converts', 'valid', 'acceptable_license', 'count', 'unique_ids_count',
+        'distinct_funding_org_identifier_count',
         'distinct_recipient_org_identifier_count', 'min_award_date',
         'max_award_date',
     ])
@@ -18,8 +19,10 @@ with open('data/report.csv', 'w') as fp:
             continue
         stats = dataset.get('datagetter_stats', {})
         writer.writerow({
+            'publisher_prefix': dataset['publisher']['prefix'],
             'publisher_name': dataset['publisher']['name'],
             'title': dataset['title'],
+            'accessURL': dataset['distribution'][0]['accessURL'],
             'downloadURL': dataset['distribution'][0]['downloadURL'],
             'file_type': dataset['datagetter_metadata'].get('file_type'),
             'datetime_downloaded': dataset['datagetter_metadata']['datetime_downloaded'],

--- a/report.py
+++ b/report.py
@@ -2,7 +2,7 @@ import csv
 import json
 from collections import defaultdict
 
-with open('data/stats.json') as fp:
+with open('data/status.json') as fp:
     data_json = json.load(fp)
 
 with open('data/report.csv', 'w') as fp:
@@ -21,7 +21,7 @@ with open('data/report.csv', 'w') as fp:
     for dataset in data_json:
         if 'datagetter_metadata' not in dataset:
             continue
-        stats = dataset.get('datagetter_stats', {})
+        stats = dataset.get('datagetter_aggregates', {})
 
         currencies = stats.get('currencies', {})
         not_GBP = defaultdict(list)

--- a/report.py
+++ b/report.py
@@ -32,5 +32,5 @@ with open('data/report.csv', 'w') as fp:
             'distinct_funding_org_identifier_count': stats.get('distinct_funding_org_identifier_count'),
             'distinct_recipient_org_identifier_count': stats.get('distinct_recipient_org_identifier_count'),
             'min_award_date': stats.get('min_award_date'),
-            'max_award_date': stats.get('min_award_date'),
+            'max_award_date': stats.get('max_award_date'),
         })

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
--e git+https://github.com/OpenDataServices/flatten-tool.git@e700b32932232660bed95fa3bcf8936bb2e351a6#egg=flattentool
+-e git+https://github.com/OpenDataServices/flatten-tool.git@v0.1.2#egg=flattentool
+-e git+https://github.com/OpenDataServices/cove.git@67a7efe1e688f443b5fc8a3a3ed1f93e4085b875#egg=cove
 jsonschema
 strict-rfc3339
 rfc3987

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,38 @@
--e git+https://github.com/OpenDataServices/flatten-tool.git@e700b32932232660bed95fa3bcf8936bb2e351a6#egg=flattentool
+-e git+https://github.com/OpenDataServices/flatten-tool.git@a2e8cfa4210187e5e381f6b461479926aed7a3fd#egg=flattentool
+-e git+https://github.com/OpenDataServices/cove.git@67a7efe1e688f443b5fc8a3a3ed1f93e4085b875#egg=cove
 jsonschema==2.6.0
 strict-rfc3339==0.7
 rfc3987==1.3.7
 rfc6266==0.0.4
 requests==2.18.4
 ijson==2.3
-## The following requirements were added by pip --freeze:
-LEPL==5.1.3
-certifi==2018.01.18
+## The following requirements were added by pip freeze:
+bleach==2.1.3
+cached-property==1.4.0
+certifi==2018.1.18
 chardet==3.0.4
+CommonMark==0.7.4
+dealer==2.0.5
+Django==1.11.11
+django-bootstrap3==9.1.0
+django-debug-toolbar==1.9.1
+django-environ==0.4.4
 et-xmlfile==1.0.1
+future==0.16.0
+html5lib==1.0.1
 idna==2.6
-jdcal==1.4
+jdcal==1.3
+json-merge-patch==0.2
 jsonref==0.1
-openpyxl==2.5.2
-pytz==2018.4
+LEPL==5.1.3
+lxml==4.2.1
+openpyxl==2.5.1
+python-dateutil==2.7.3
+pytz==2018.3
+raven==6.6.0
 schema==0.6.7
 six==1.11.0
+sqlparse==0.2.4
 urllib3==1.22
+webencodings==0.5.1
 xmltodict==0.11.0

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ rm -r data || true
 mkdir -p data/{original,json_all,json_valid,json_acceptable_license,json_acceptable_license_valid}
 echo 'Fetching and converting data'
 python get.py $@
-python stats.py
+python aggregates.py
 echo 'Generating report.csv'
 python report.py
 echo 'Creating tarball'

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,8 @@ set -e
 rm -r data || true
 mkdir -p data/{original,json_all,json_valid,json_acceptable_license,json_acceptable_license_valid}
 echo 'Fetching and converting data'
-python get.py
+python get.py $@
+python stats.py
 echo 'Generating report.csv'
 python report.py
 echo 'Creating tarball'

--- a/stats.py
+++ b/stats.py
@@ -1,0 +1,22 @@
+import json
+from cove_360.lib.threesixtygiving import get_grants_aggregates
+
+data_all = json.load(open('data/data_all.json')) 
+stats = []
+
+for dataset in data_all:
+    json_filename = dataset['datagetter_metadata'].get('json')
+    if not json_filename:
+        continue
+    with open(json_filename) as fp:
+        aggregates = get_grants_aggregates(json.load(fp))
+    # replace sets with counts
+    for k, v in aggregates.items():
+        if isinstance(v, set):
+            aggregates[k+'_count'] = len(v)
+            del aggregates[k]
+    aggregates = {k:sorted(list(v)) if isinstance(v, set) else v for k,v in aggregates.items()}
+    stats.append(aggregates)
+    with open('data/stats.json', 'w') as fp:
+        json.dump(stats, fp, indent='  ')
+        

--- a/stats.py
+++ b/stats.py
@@ -6,17 +6,16 @@ stats = []
 
 for dataset in data_all:
     json_filename = dataset['datagetter_metadata'].get('json')
-    if not json_filename:
-        continue
-    with open(json_filename) as fp:
-        aggregates = get_grants_aggregates(json.load(fp))
-    # replace sets with counts
-    for k, v in aggregates.items():
-        if isinstance(v, set):
-            aggregates[k+'_count'] = len(v)
-            del aggregates[k]
-    aggregates = {k:sorted(list(v)) if isinstance(v, set) else v for k,v in aggregates.items()}
-    dataset['datagetter_stats'] = aggregates
+    if json_filename:
+        with open(json_filename) as fp:
+            aggregates = get_grants_aggregates(json.load(fp))
+        # replace sets with counts
+        for k, v in aggregates.items():
+            if isinstance(v, set):
+                aggregates[k+'_count'] = len(v)
+                del aggregates[k]
+        aggregates = {k:sorted(list(v)) if isinstance(v, set) else v for k,v in aggregates.items()}
+        dataset['datagetter_stats'] = aggregates
     stats.append(dataset)
     with open('data/stats.json', 'w') as fp:
         json.dump(stats, fp, indent='  ', sort_keys=True)

--- a/stats.py
+++ b/stats.py
@@ -16,7 +16,7 @@ for dataset in data_all:
             aggregates[k+'_count'] = len(v)
             del aggregates[k]
     aggregates = {k:sorted(list(v)) if isinstance(v, set) else v for k,v in aggregates.items()}
-    stats.append(aggregates)
+    dataset['datagetter_stats'] = aggregates
+    stats.append(dataset)
     with open('data/stats.json', 'w') as fp:
-        json.dump(stats, fp, indent='  ')
-        
+        json.dump(stats, fp, indent='  ', sort_keys=True)

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -4,7 +4,16 @@
 rm -rf .ve
 virtualenv --python=python3 .ve
 source .ve/bin/activate
-pip install --upgrade -r requirements.in
+if [[ "$1" == "--new-only" ]]; then
+    # If --new-only is supplied then we install the current versions of
+    # packages into the virtualenv, so that the only change will be any new
+    # packages and their dependencies.
+    pip install -r requirements.txt
+    dashupgrade=""
+else
+    dashupgrade="--upgrade"
+fi
+pip install $dashupgrade -r requirements.in
 pip freeze -r requirements.in | grep -v 'pkg-resources' > requirements.txt
 # Put comments back on the same line (mostly for requires.io's benefit)
 sed -i '$!N;s/\n#\^\^/ #/;P;D' requirements*txt


### PR DESCRIPTION
Add `stats.py`, which creates `data/stats.json`, which is `data/data_all.json` but with aggregates added by running the `get_grants_aggregates` function from CoVE.
We also add some of these stats to `report.csv` using `report.py`.

Also sets up the datagetter to run on Travis, which is more flexible than the current run as part of test_registry (e.g. we can run multiple branches). Also this is not really about testing the registry anymore either. Here's the PR to remove from test_registry https://github.com/ThreeSixtyGiving/test_registry/pull/6. These two PR want merging at the same time, and also the url in A3 of https://docs.google.com/spreadsheets/d/1iRH0N07Fi-XM6HcZLSR688EiPA4EQGc5wSP1hJIx3L4/edit#gid=0 updating.

Files are uploaded to Google Cloud Storage, instead of github gist. This is better than github gist, as we can have a directory structure with different directories for each branch. e.g. for the `stats` branch that I've been doing the work on:
https://storage.googleapis.com/datagetter-360giving-output/branch/stats/status.json
https://storage.googleapis.com/datagetter-360giving-output/branch/stats/report.csv

Here's the report.csv loaded into a google doc:
https://docs.google.com/spreadsheets/d/18XKIC-zBQi9iD6xh3KivtIkUjs8t5Mjs9qf883FwBPY/edit#gid=0