### PR TITLE
Use latest openpyxl 2.5 branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e hg+https://bitbucket.org/openpyxl/openpyxl#egg=openpyxl
 -e git+https://github.com/OpenDataServices/flatten-tool.git@a2e8cfa4210187e5e381f6b461479926aed7a3fd#egg=flattentool
 -e git+https://github.com/OpenDataServices/cove.git@67a7efe1e688f443b5fc8a3a3ed1f93e4085b875#egg=cove
 jsonschema==2.6.0
@@ -26,7 +27,6 @@ json-merge-patch==0.2
 jsonref==0.1
 LEPL==5.1.3
 lxml==4.2.1
-openpyxl==2.5.1
 python-dateutil==2.7.3
 pytz==2018.3
 raven==6.6.0


### PR DESCRIPTION
This contains the fix for [mac base dates](https://bitbucket.org/openpyxl/openpyxl/issues/1049) which hasn't made its way into a release yet.

@BibianaC @robredpath I think we probably want to merge this PR before the upcoming GrantNav data fetch, in order to get Cabinet Office's dates correct.