### PR TITLE
Try the new pip resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A [CSV report](https://gist.github.com/30d835ae16e2a30efde8a63acf03628d) of all 
 Install dependencies:
 
 ```
-python3 -m virtualenv -p $(which python3) .ve
+python3 -m venv .ve
 source .ve/bin/activate
 pip install -r requirements.txt
 ```

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -2,7 +2,7 @@
 # This follows broadly the approach from
 # http://www.kennethreitz.org/essays/a-better-pip-workflow
 rm -rf .ve
-virtualenv --python=python3 .ve
+python3 -m venv .ve
 source .ve/bin/activate
 if [[ "$1" == "--new-only" ]]; then
     # If --new-only is supplied then we install the current versions of

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -4,16 +4,17 @@
 rm -rf .ve
 python3 -m venv .ve
 source .ve/bin/activate
+pip install --upgrade pip
 if [[ "$1" == "--new-only" ]]; then
     # If --new-only is supplied then we install the current versions of
     # packages into the virtualenv, so that the only change will be any new
     # packages and their dependencies.
-    pip install -r requirements.txt
+    pip install --use-feature=2020-resolver -r requirements.txt
     dashupgrade=""
 else
     dashupgrade="--upgrade"
 fi
-pip install $dashupgrade -r requirements.in
+pip install --use-feature=2020-resolver $dashupgrade -r requirements.in
 pip freeze -r requirements.in | grep -v 'pkg-resources' > requirements.txt
 # Put comments back on the same line (mostly for requires.io's benefit)
 sed -i '$!N;s/\n#\^\^/ #/;P;D' requirements*txt


### PR DESCRIPTION
In pip 20.3, which will be released in October, there will be a new dependency resolver used by default in pip.
The resolver is available in the current pip 20.2 behind a flag.

The new resolver is stricter, but easier to reason about. At the moment if "A requires B which requires D(v1)" and "A requires C which requires D(v2)" then the installation will happen successfully, with D(v1) or D(v2) picked depending on the order the requirements are listed. With the new resolver, this case will error out, and D will not be installed.

This is a big problem for this repo, because it depends on cove and datagetter, which both have pinned dependencies. If the dependencies don't match versions, then the new resolver will fail.
To see this in action, check out this PR, and run the `./update_requirements.sh` script.

Options for fixing this:
1) Update the pinned version of cove and datagetter to match exactly where they overlap
2) Update one or both of cove/datagetter to not pin versions (at least when installed via setup.py)
3) Refactor the code out of cove into a lib-cove-360

@michaelwood What do you think? Happy to have a quick call about this.