### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,56 +4,237 @@
 #
 #    pip-compile
 #
--e git+https://github.com/OpenDataServices/cove.git@live#egg=cove  # via -r requirements.in
--e git+https://github.com/threesixtygiving/datagetter.git@master#egg=datagetter  # via -r requirements.in
-attrs==19.3.0             # via cove, datagetter, jsonschema
-bleach==3.1.5             # via cove
-cached-property==1.5.1    # via cove, libcove, libcoveweb
-certifi==2020.6.20        # via cove, datagetter, requests, sentry-sdk
-chardet==3.0.4            # via cove, datagetter, requests
-commonmark==0.9.1         # via cove, libcove
-contextlib2==0.6.0.post1  # via cove, datagetter, schema
-dealer==2.1.0             # via cove, libcoveweb
-defusedxml==0.6.0         # via cove, odfpy
-django-bootstrap3==12.1.0  # via cove, libcoveweb
-django-debug-toolbar==2.2  # via cove, libcoveweb
-django-environ==0.4.5     # via cove, libcoveweb
-django==2.2.15            # via cove, django-debug-toolbar, libcoveweb
-et_xmlfile==1.0.1         # via cove, datagetter, openpyxl
-flattentool==0.15.2       # via cove, datagetter, libcove
-idna==2.10                # via cove, datagetter, requests
-ijson==2.4                # via -r requirements.in
-importlib-metadata==1.7.0  # via cove, datagetter, jsonschema
-jdcal==1.4.1              # via cove, datagetter, openpyxl
-json-merge-patch==0.2     # via cove, libcove, libcoveweb
-jsonref==0.2              # via cove, datagetter, flattentool, libcove, libcoveweb
-jsonschema==3.2.0         # via cove, datagetter, libcove, libcoveweb
-lepl==5.1.3               # via cove, datagetter, rfc6266
-libcove==0.20.1           # via cove, libcoveweb
-libcoveweb==0.18.1        # via cove
-lxml==4.5.2               # via cove, datagetter, flattentool
-odfpy==1.4.1              # via cove, flattentool
-openpyxl==2.6.4           # via cove, datagetter, flattentool, libcoveweb
-packaging==20.4           # via bleach, cove
-pyparsing==2.4.7          # via cove, packaging
-pyrsistent==0.16.0        # via cove, datagetter, jsonschema
-pysocks==1.7.1            # via datagetter, requests
-python-dateutil==2.8.1    # via cove, libcoveweb
-pytz==2020.1              # via cove, datagetter, django, flattentool
-rangedict==0.1.6          # via cove
-raven==6.10.0             # via cove
-requests==2.24.0          # via cove, datagetter, libcove, libcoveweb
-rfc3987==1.3.8            # via cove, datagetter, libcove, libcoveweb
-rfc6266==0.0.4            # via cove, datagetter, libcoveweb
-schema==0.7.3             # via cove, datagetter, flattentool
-sentry-sdk==0.16.5        # via cove, libcoveweb
-six==1.15.0               # via bleach, cove, datagetter, jsonschema, packaging, pyrsistent, python-dateutil
-sqlparse==0.3.1           # via cove, django, django-debug-toolbar
-strict-rfc3339==0.7       # via cove, datagetter, libcove, libcoveweb
-urllib3==1.25.10          # via cove, datagetter, requests, sentry-sdk
-webencodings==0.5.1       # via bleach, cove
-xmltodict==0.12.0         # via cove, datagetter, flattentool, libcoveweb
-zipp==1.2.0               # via cove, datagetter, importlib-metadata, libcoveweb
+-e git+https://github.com/OpenDataServices/cove.git@live#egg=cove
+    # via -r requirements.in
+-e git+https://github.com/threesixtygiving/datagetter.git@master#egg=datagetter
+    # via -r requirements.in
+attrs==19.3.0
+    # via
+    #   cove
+    #   datagetter
+    #   jsonschema
+bleach==3.3.0
+    # via cove
+cached-property==1.5.1
+    # via
+    #   cove
+    #   libcove
+    #   libcoveweb
+certifi==2020.6.20
+    # via
+    #   cove
+    #   datagetter
+    #   requests
+    #   sentry-sdk
+chardet==3.0.4
+    # via
+    #   cove
+    #   datagetter
+    #   requests
+commonmark==0.9.1
+    # via
+    #   cove
+    #   libcove
+contextlib2==0.6.0.post1
+    # via
+    #   cove
+    #   datagetter
+    #   schema
+dealer==2.1.0
+    # via
+    #   cove
+    #   libcoveweb
+defusedxml==0.6.0
+    # via
+    #   cove
+    #   odfpy
+django-bootstrap3==12.1.0
+    # via
+    #   cove
+    #   libcoveweb
+django-debug-toolbar==2.2
+    # via
+    #   cove
+    #   libcoveweb
+django-environ==0.4.5
+    # via
+    #   cove
+    #   libcoveweb
+django==2.2.15
+    # via
+    #   cove
+    #   django-debug-toolbar
+    #   libcoveweb
+et-xmlfile==1.0.1
+    # via
+    #   cove
+    #   datagetter
+    #   openpyxl
+flattentool==0.15.2
+    # via
+    #   cove
+    #   datagetter
+    #   libcove
+idna==2.10
+    # via
+    #   cove
+    #   datagetter
+    #   requests
+ijson==2.4
+    # via -r requirements.in
+importlib-metadata==1.7.0
+    # via
+    #   cove
+    #   datagetter
+    #   jsonschema
+jdcal==1.4.1
+    # via
+    #   cove
+    #   datagetter
+    #   openpyxl
+json-merge-patch==0.2
+    # via
+    #   cove
+    #   libcove
+    #   libcoveweb
+jsonref==0.2
+    # via
+    #   cove
+    #   datagetter
+    #   flattentool
+    #   libcove
+    #   libcoveweb
+jsonschema==3.2.0
+    # via
+    #   cove
+    #   datagetter
+    #   libcove
+    #   libcoveweb
+lepl==5.1.3
+    # via
+    #   cove
+    #   datagetter
+    #   rfc6266
+libcove==0.20.1
+    # via
+    #   cove
+    #   libcoveweb
+libcoveweb==0.18.1
+    # via cove
+lxml==4.5.2
+    # via
+    #   cove
+    #   datagetter
+    #   flattentool
+odfpy==1.4.1
+    # via
+    #   cove
+    #   flattentool
+openpyxl==2.6.4
+    # via
+    #   cove
+    #   datagetter
+    #   flattentool
+    #   libcoveweb
+packaging==20.4
+    # via
+    #   bleach
+    #   cove
+pyparsing==2.4.7
+    # via
+    #   cove
+    #   packaging
+pyrsistent==0.16.0
+    # via
+    #   cove
+    #   datagetter
+    #   jsonschema
+pysocks==1.7.1
+    # via
+    #   datagetter
+    #   requests
+python-dateutil==2.8.1
+    # via
+    #   cove
+    #   libcoveweb
+pytz==2020.1
+    # via
+    #   cove
+    #   datagetter
+    #   django
+    #   flattentool
+rangedict==0.1.6
+    # via cove
+raven==6.10.0
+    # via cove
+requests[socks]==2.24.0
+    # via
+    #   cove
+    #   datagetter
+    #   libcove
+    #   libcoveweb
+rfc3987==1.3.8
+    # via
+    #   cove
+    #   datagetter
+    #   libcove
+    #   libcoveweb
+rfc6266==0.0.4
+    # via
+    #   cove
+    #   datagetter
+    #   libcoveweb
+schema==0.7.3
+    # via
+    #   cove
+    #   datagetter
+    #   flattentool
+sentry-sdk==0.16.5
+    # via
+    #   cove
+    #   libcoveweb
+six==1.15.0
+    # via
+    #   bleach
+    #   cove
+    #   datagetter
+    #   jsonschema
+    #   packaging
+    #   pyrsistent
+    #   python-dateutil
+sqlparse==0.3.1
+    # via
+    #   cove
+    #   django
+    #   django-debug-toolbar
+strict-rfc3339==0.7
+    # via
+    #   cove
+    #   datagetter
+    #   libcove
+    #   libcoveweb
+urllib3==1.25.10
+    # via
+    #   cove
+    #   datagetter
+    #   requests
+    #   sentry-sdk
+webencodings==0.5.1
+    # via
+    #   bleach
+    #   cove
+xmltodict==0.12.0
+    # via
+    #   cove
+    #   datagetter
+    #   flattentool
+    #   libcoveweb
+zipp==1.2.0
+    # via
+    #   cove
+    #   datagetter
+    #   importlib-metadata
+    #   libcoveweb
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Bleach had a vulnerable version. Cove was updated with the latest version 3.3.0.